### PR TITLE
Add guarded routing for authenticated and admin-only pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import Register from "./pages/Register";
 import Orders from "./pages/Orders";
 import Admin from "./pages/Admin";
 import NotFound from "./pages/NotFound";
+import RequireAuth from "@/components/routes/RequireAuth";
+import RequireAdmin from "@/components/routes/RequireAdmin";
 
 const queryClient = new QueryClient();
 
@@ -32,8 +34,12 @@ const App = () => (
               <Route path="/cart" element={<Cart />} />
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />
-              <Route path="/orders" element={<Orders />} />
-              <Route path="/admin" element={<Admin />} />
+              <Route element={<RequireAuth />}>
+                <Route path="/orders" element={<Orders />} />
+              </Route>
+              <Route element={<RequireAdmin />}>
+                <Route path="/admin" element={<Admin />} />
+              </Route>
               <Route path="*" element={<NotFound />} />
             </Routes>
           </main>

--- a/src/components/routes/AuthGuardFallback.tsx
+++ b/src/components/routes/AuthGuardFallback.tsx
@@ -1,0 +1,8 @@
+const AuthGuardFallback = () => (
+  <div className="flex items-center justify-center py-16">
+    <div className="h-6 w-6 animate-spin rounded-full border-2 border-pizza-600 border-t-transparent" />
+    <span className="ml-3 text-sm text-gray-600">Preparing your experience...</span>
+  </div>
+);
+
+export default AuthGuardFallback;

--- a/src/components/routes/RequireAdmin.tsx
+++ b/src/components/routes/RequireAdmin.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren, useEffect, useRef } from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useAuthStore } from '@/store/authStore';
+import { useAuthHydration } from './useAuthHydration';
+import AuthGuardFallback from './AuthGuardFallback';
+
+const RequireAdmin = ({ children }: PropsWithChildren) => {
+  const location = useLocation();
+  const hasHydrated = useAuthHydration();
+  const { isAuthenticated, isAdmin } = useAuthStore((state) => ({
+    isAuthenticated: state.isAuthenticated,
+    isAdmin: state.isAdmin,
+  }));
+  const hasNotified = useRef(false);
+
+  useEffect(() => {
+    if (!hasHydrated) {
+      return;
+    }
+
+    if (isAuthenticated && !isAdmin && !hasNotified.current) {
+      toast.error('You do not have access to this page');
+      hasNotified.current = true;
+    }
+  }, [hasHydrated, isAuthenticated, isAdmin]);
+
+  if (!hasHydrated) {
+    return <AuthGuardFallback />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (children) {
+    return <>{children}</>;
+  }
+
+  return <Outlet />;
+};
+
+export default RequireAdmin;

--- a/src/components/routes/RequireAuth.tsx
+++ b/src/components/routes/RequireAuth.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren } from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuthStore } from '@/store/authStore';
+import { useAuthHydration } from './useAuthHydration';
+import AuthGuardFallback from './AuthGuardFallback';
+
+const RequireAuth = ({ children }: PropsWithChildren) => {
+  const location = useLocation();
+  const hasHydrated = useAuthHydration();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  if (!hasHydrated) {
+    return <AuthGuardFallback />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (children) {
+    return <>{children}</>;
+  }
+
+  return <Outlet />;
+};
+
+export default RequireAuth;

--- a/src/components/routes/useAuthHydration.ts
+++ b/src/components/routes/useAuthHydration.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/store/authStore';
+
+export const useAuthHydration = () => {
+  const [hasHydrated, setHasHydrated] = useState(() => {
+    const persist = useAuthStore.persist;
+    return persist?.hasHydrated?.() ?? true;
+  });
+
+  useEffect(() => {
+    const persist = useAuthStore.persist;
+
+    if (!persist?.onFinishHydration || !persist?.hasHydrated) {
+      return;
+    }
+
+    if (persist.hasHydrated()) {
+      setHasHydrated(true);
+      return;
+    }
+
+    setHasHydrated(false);
+
+    const unsubscribe = persist.onFinishHydration(() => {
+      setHasHydrated(true);
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
+
+  return hasHydrated;
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,7 +1,4 @@
 
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useAuthStore } from '@/store/authStore';
 import { useOrderStore } from '@/store/orderStore';
 import {
   Select,
@@ -14,18 +11,9 @@ import { format } from 'date-fns';
 import { toast } from 'sonner';
 
 const Admin = () => {
-  const navigate = useNavigate();
-  const { isAuthenticated, isAdmin } = useAuthStore();
   const { getAllOrders, updateOrderStatus } = useOrderStore();
 
   const orders = getAllOrders();
-
-  useEffect(() => {
-    if (!isAuthenticated || !isAdmin) {
-      toast.error('You do not have access to this page');
-      navigate('/');
-    }
-  }, [isAuthenticated, isAdmin, navigate]);
 
   const handleStatusChange = (orderId: string, status: 'pending' | 'processing' | 'completed' | 'cancelled') => {
     updateOrderStatus(orderId, status);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 
 import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -14,6 +14,8 @@ const Login = () => {
   
   const { login } = useAuthStore();
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname ?? '/';
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,7 +32,7 @@ const Login = () => {
 
       if (result.success) {
         toast.success('Login successful');
-        navigate('/');
+        navigate(from, { replace: true });
       } else if (result.error === 'username') {
         toast.error('We couldn\'t find an account with that username');
       } else {

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,5 +1,4 @@
 
-import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useOrderStore } from '@/store/orderStore';
@@ -43,14 +42,8 @@ const OrderStatus = ({ status }: { status: string }) => {
 
 const Orders = () => {
   const navigate = useNavigate();
-  const { isAuthenticated, user, isAdmin } = useAuthStore();
+  const { user, isAdmin } = useAuthStore();
   const { getUserOrders, getAllOrders } = useOrderStore();
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate('/login');
-    }
-  }, [isAuthenticated, navigate]);
 
   const orders = isAdmin ? getAllOrders() : getUserOrders(user?.id || '');
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -119,5 +120,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add reusable `RequireAuth` and `RequireAdmin` route guards with a hydration-aware fallback and admin access notifications
- nest protected routes under the new guards, streamline Orders/Admin screens, and support redirecting back to the originally requested page after login
- address lint errors surfaced during the change by swapping empty interfaces for type aliases and replacing the Tailwind plugin require with an ES import

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cb160ad10883298d8125a8b18fdfb8