### PR TITLE
Add checkout flow with delivery details and payment capture

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Register from "./pages/Register";
 import Orders from "./pages/Orders";
 import Admin from "./pages/Admin";
 import NotFound from "./pages/NotFound";
+import Checkout from "./pages/Checkout";
 import RequireAuth from "@/components/routes/RequireAuth";
 import RequireAdmin from "@/components/routes/RequireAdmin";
 
@@ -35,6 +36,7 @@ const App = () => (
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />
               <Route element={<RequireAuth />}>
+                <Route path="/checkout" element={<Checkout />} />
                 <Route path="/orders" element={<Orders />} />
               </Route>
               <Route element={<RequireAdmin />}>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -50,6 +50,12 @@ const Admin = () => {
                     Status
                   </th>
                   <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Delivery
+                  </th>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Payment
+                  </th>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Items
                   </th>
                 </tr>
@@ -73,7 +79,7 @@ const Admin = () => {
                       <Select
                         value={order.status}
                         onValueChange={(value) => handleStatusChange(
-                          order.id, 
+                          order.id,
                           value as 'pending' | 'processing' | 'completed' | 'cancelled'
                         )}
                       >
@@ -87,6 +93,24 @@ const Admin = () => {
                           <SelectItem value="cancelled">Cancelled</SelectItem>
                         </SelectContent>
                       </Select>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <div>
+                        <p className="font-medium text-gray-900">{order.contact.name || 'N/A'}</p>
+                        <p>{order.contact.phone || 'N/A'}</p>
+                        <p className="truncate max-w-[200px]" title={order.delivery.address}>
+                          {order.delivery.address || 'N/A'}
+                        </p>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <p className="capitalize">{order.payment.method.replace('-', ' ')}</p>
+                      <p className="capitalize text-gray-400">{(order.payment.status ?? 'pending').replace('-', ' ')}</p>
+                      {order.delivery.instructions && (
+                        <p className="text-gray-400 text-xs truncate max-w-[200px]" title={order.delivery.instructions}>
+                          Notes: {order.delivery.instructions}
+                        </p>
+                      )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                       {order.items.length} items

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useCartStore } from '@/store/cartStore';
 import { useAuthStore } from '@/store/authStore';
-import { useOrderStore } from '@/store/orderStore';
+import { useCheckoutStore } from '@/store/checkoutStore';
 import { pizzas } from '@/data/pizzas';
 import { drinks } from '@/data/drinks';
 import { toppings } from '@/data/toppings';
@@ -11,11 +11,11 @@ import { toast } from 'sonner';
 
 const Cart = () => {
   const navigate = useNavigate();
-  const { items, removeFromCart, updateItemQuantity, clearCart, getTotalPrice } = useCartStore();
-  const { isAuthenticated, user } = useAuthStore();
-  const { placeOrder } = useOrderStore();
+  const { items, removeFromCart, updateItemQuantity, getTotalPrice } = useCartStore();
+  const { isAuthenticated } = useAuthStore();
+  const { setSnapshot } = useCheckoutStore();
 
-  const handlePlaceOrder = () => {
+  const handleCheckout = () => {
     if (!isAuthenticated) {
       toast.error('Please login to place an order');
       navigate('/login');
@@ -27,11 +27,9 @@ const Cart = () => {
       return;
     }
 
-    const orderId = placeOrder(user!.id, items, getTotalPrice());
-    clearCart();
-    
-    toast.success('Order placed successfully!');
-    navigate('/orders');
+    setSnapshot(items, getTotalPrice());
+    toast.info('Review your order and delivery details.');
+    navigate('/checkout');
   };
 
   const getPizzaById = (id: string) => pizzas.find(pizza => pizza.id === id);
@@ -216,9 +214,9 @@ const Cart = () => {
             <div className="mt-6 space-y-3">
               <Button
                 className="w-full bg-pizza-600 hover:bg-pizza-700"
-                onClick={handlePlaceOrder}
+                onClick={handleCheckout}
               >
-                Place Order
+                Checkout
               </Button>
               <Button
                 variant="outline"

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCheckoutStore } from '@/store/checkoutStore';
+import { useOrderStore } from '@/store/orderStore';
+import { useCartStore } from '@/store/cartStore';
+import { useAuthStore } from '@/store/authStore';
+import { pizzas } from '@/data/pizzas';
+import { drinks } from '@/data/drinks';
+import { toppings } from '@/data/toppings';
+
+const checkoutSchema = z.object({
+  name: z.string().min(2, 'Please enter your full name'),
+  phone: z
+    .string()
+    .min(7, 'Please enter a valid phone number')
+    .max(20, 'Phone number is too long'),
+  address: z.string().min(5, 'Please provide your delivery address'),
+  instructions: z
+    .string()
+    .max(200, 'Delivery instructions must be 200 characters or fewer')
+    .optional(),
+  paymentMethod: z.enum(['cash', 'card']),
+});
+
+type CheckoutFormValues = z.infer<typeof checkoutSchema>;
+
+const Checkout = () => {
+  const navigate = useNavigate();
+  const { snapshot, clearSnapshot } = useCheckoutStore();
+  const { placeOrder } = useOrderStore();
+  const { clearCart } = useCartStore();
+  const { user } = useAuthStore();
+
+  useEffect(() => {
+    if (!snapshot || snapshot.items.length === 0) {
+      toast.error('Your checkout session has expired. Please start again.');
+      navigate('/cart', { replace: true });
+    }
+  }, [snapshot, navigate]);
+
+  const defaultName = useMemo(() => {
+    if (!user) return '';
+    const parts = [user.firstName, user.lastName].filter(Boolean);
+    return parts.join(' ');
+  }, [user]);
+
+  const form = useForm<CheckoutFormValues>({
+    resolver: zodResolver(checkoutSchema),
+    defaultValues: {
+      name: defaultName,
+      phone: user?.phone ?? '',
+      address: '',
+      instructions: '',
+      paymentMethod: 'cash',
+    },
+  });
+
+  useEffect(() => {
+    form.setValue('name', defaultName);
+  }, [defaultName, form]);
+
+  useEffect(() => {
+    form.setValue('phone', user?.phone ?? '');
+  }, [user, form]);
+
+  const getPizzaById = (id: string) => pizzas.find(pizza => pizza.id === id);
+  const getDrinkById = (id: string) => drinks.find(drink => drink.id === id);
+  const getToppingById = (id: string) => toppings.find(topping => topping.id === id);
+
+  const onSubmit = (values: CheckoutFormValues) => {
+    if (!snapshot || !user) {
+      toast.error('Unable to submit your order. Please try again.');
+      return;
+    }
+
+    placeOrder({
+      userId: user.id,
+      items: snapshot.items,
+      total: snapshot.total,
+      contact: {
+        name: values.name.trim(),
+        phone: values.phone.trim(),
+      },
+      delivery: {
+        address: values.address.trim(),
+        instructions: values.instructions?.trim() ? values.instructions.trim() : undefined,
+      },
+      payment: {
+        method: values.paymentMethod,
+        status: 'pending',
+      },
+    });
+
+    clearCart();
+    clearSnapshot();
+    toast.success('Order placed successfully!');
+    navigate('/orders');
+  };
+
+  if (!snapshot || snapshot.items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 md:py-16">
+      <h1 className="text-3xl md:text-4xl font-bold mb-8">Checkout</h1>
+
+      <div className="grid gap-8 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <div className="bg-white rounded-lg shadow-sm p-6">
+            <h2 className="font-semibold text-xl mb-4">Delivery Details</h2>
+
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Full Name</FormLabel>
+                      <FormControl>
+                        <Input placeholder="John Doe" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Phone Number</FormLabel>
+                      <FormControl>
+                        <Input placeholder="(555) 123-4567" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="address"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Delivery Address</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="123 Pizza Street, Flavor Town"
+                          className="min-h-[100px]"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="instructions"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Delivery Instructions (Optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Ring the bell, call upon arrival, etc."
+                          className="min-h-[80px]"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="paymentMethod"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Payment Method</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a payment method" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="cash">Cash on Delivery</SelectItem>
+                          <SelectItem value="card">Card on Delivery</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <Button
+                  type="submit"
+                  className="w-full bg-pizza-600 hover:bg-pizza-700"
+                  disabled={form.formState.isSubmitting}
+                >
+                  {form.formState.isSubmitting ? 'Placing Order...' : 'Place Order'}
+                </Button>
+              </form>
+            </Form>
+          </div>
+        </div>
+
+        <div>
+          <div className="bg-white rounded-lg shadow-sm p-6 sticky top-24">
+            <h2 className="font-semibold text-xl mb-4">Order Summary</h2>
+            <div className="space-y-4">
+              {snapshot.items.map(item => {
+                if (item.type === 'pizza' && item.pizza) {
+                  const pizza = getPizzaById(item.pizza.pizzaId);
+                  if (!pizza) return null;
+
+                  return (
+                    <div key={item.id} className="border-b pb-4 last:border-b-0 last:pb-0">
+                      <p className="font-medium">
+                        {item.pizza.quantity} × {pizza.name} ({item.pizza.size})
+                      </p>
+                      {item.pizza.toppings.length > 0 && (
+                        <p className="text-sm text-gray-600">
+                          <span className="font-medium">Toppings:</span>{' '}
+                          {item.pizza.toppings
+                            .map(toppingId => getToppingById(toppingId)?.name)
+                            .filter(Boolean)
+                            .join(', ')}
+                        </p>
+                      )}
+                    </div>
+                  );
+                }
+
+                if (item.type === 'drink' && item.drink) {
+                  const drink = getDrinkById(item.drink.drinkId);
+                  if (!drink) return null;
+
+                  return (
+                    <div key={item.id} className="border-b pb-4 last:border-b-0 last:pb-0">
+                      <p className="font-medium">
+                        {item.drink.quantity} × {drink.name} ({drink.size})
+                      </p>
+                    </div>
+                  );
+                }
+
+                return null;
+              })}
+            </div>
+
+            <div className="mt-6 pt-4 border-t">
+              <div className="flex justify-between font-medium text-lg">
+                <span>Total</span>
+                <span>${snapshot.total.toFixed(2)}</span>
+              </div>
+              <p className="text-xs text-gray-500 mt-2">
+                Review your details before placing the order. You can always return to the cart if you need to make changes.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Checkout;

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -95,6 +95,41 @@ const Orders = () => {
               </div>
             </div>
 
+            <div className="grid gap-4 md:grid-cols-2 border-t pt-4">
+              <div>
+                <h3 className="font-medium mb-1">Delivery Details</h3>
+                <p className="text-sm text-gray-700">
+                  <span className="font-medium">Contact:</span>{' '}
+                  {order.contact.name || 'N/A'}
+                </p>
+                <p className="text-sm text-gray-700">
+                  <span className="font-medium">Phone:</span>{' '}
+                  {order.contact.phone || 'N/A'}
+                </p>
+                <p className="text-sm text-gray-700">
+                  <span className="font-medium">Address:</span>{' '}
+                  {order.delivery.address || 'N/A'}
+                </p>
+                {order.delivery.instructions && (
+                  <p className="text-sm text-gray-700">
+                    <span className="font-medium">Instructions:</span>{' '}
+                    {order.delivery.instructions}
+                  </p>
+                )}
+              </div>
+              <div>
+                <h3 className="font-medium mb-1">Payment</h3>
+                <p className="text-sm text-gray-700 capitalize">
+                  <span className="font-medium">Method:</span>{' '}
+                  {order.payment.method.replace('-', ' ')}
+                </p>
+                <p className="text-sm text-gray-700 capitalize">
+                  <span className="font-medium">Status:</span>{' '}
+                  {order.payment.status ?? 'pending'}
+                </p>
+              </div>
+            </div>
+
             <div className="border-t pt-4">
               <h3 className="font-medium mb-2">Order Items</h3>
               <div className="space-y-3">

--- a/src/store/checkoutStore.ts
+++ b/src/store/checkoutStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { CartItem, CheckoutSnapshot } from '../types';
+
+interface CheckoutState {
+  snapshot: CheckoutSnapshot | null;
+  setSnapshot: (items: CartItem[], total: number) => void;
+  clearSnapshot: () => void;
+}
+
+const cloneCartItems = (items: CartItem[]): CartItem[] =>
+  items.map(item => ({
+    ...item,
+    pizza: item.pizza
+      ? {
+          ...item.pizza,
+          toppings: [...item.pizza.toppings],
+        }
+      : undefined,
+    drink: item.drink ? { ...item.drink } : undefined,
+  }));
+
+export const useCheckoutStore = create<CheckoutState>()(
+  persist(
+    (set) => ({
+      snapshot: null,
+      setSnapshot: (items, total) => {
+        set({
+          snapshot: {
+            items: cloneCartItems(items),
+            total,
+            createdAt: new Date().toISOString(),
+          },
+        });
+      },
+      clearSnapshot: () => set({ snapshot: null }),
+    }),
+    {
+      name: 'pizza-checkout-storage',
+    }
+  )
+);

--- a/src/store/orderStore.ts
+++ b/src/store/orderStore.ts
@@ -1,12 +1,12 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { Order, CartItem } from '../types';
+import { Order, CreateOrderInput } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 
 interface OrderState {
   orders: Order[];
-  placeOrder: (userId: string, items: CartItem[], total: number) => string;
+  placeOrder: (orderInput: CreateOrderInput) => string;
   getUserOrders: (userId: string) => Order[];
   getAllOrders: () => Order[];
   updateOrderStatus: (orderId: string, status: 'pending' | 'processing' | 'completed' | 'cancelled') => void;
@@ -17,16 +17,39 @@ export const useOrderStore = create<OrderState>()(
     (set, get) => ({
       orders: [],
       
-      placeOrder: (userId, items, total) => {
+      placeOrder: ({ userId, items, total, contact, delivery, payment }) => {
+        const clonedItems = items.map(item => ({
+          ...item,
+          pizza: item.pizza
+            ? {
+                ...item.pizza,
+                toppings: [...item.pizza.toppings],
+              }
+            : undefined,
+          drink: item.drink ? { ...item.drink } : undefined,
+        }));
+
         const newOrder: Order = {
           id: uuidv4(),
           userId,
-          items: [...items],
+          items: clonedItems,
           total,
           status: 'pending',
           createdAt: new Date().toISOString(),
+          contact: {
+            name: contact.name.trim(),
+            phone: contact.phone.trim(),
+          },
+          delivery: {
+            address: delivery.address.trim(),
+            instructions: delivery.instructions?.trim() || undefined,
+          },
+          payment: {
+            method: payment.method,
+            status: payment.status ?? 'pending',
+          },
         };
-        
+
         set(state => ({
           orders: [...state.orders, newOrder]
         }));
@@ -52,6 +75,36 @@ export const useOrderStore = create<OrderState>()(
     }),
     {
       name: 'pizza-order-storage',
+      version: 1,
+      migrate: (persistedState: unknown, version) => {
+        if (!persistedState || typeof persistedState !== 'object') {
+          return { orders: [] };
+        }
+
+        if (version === 0) {
+          const state = persistedState as { orders?: Order[] };
+          return {
+            ...state,
+            orders: (state.orders ?? []).map(order => ({
+              ...order,
+              contact: order.contact ?? {
+                name: '',
+                phone: '',
+              },
+              delivery: order.delivery ?? {
+                address: '',
+                instructions: undefined,
+              },
+              payment: order.payment ?? {
+                method: 'cash',
+                status: 'pending',
+              },
+            })),
+          };
+        }
+
+        return persistedState;
+      },
     }
   )
 );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,25 @@ export interface CartItem {
   drink?: CartDrinkItem;
 }
 
+export type PaymentMethod = 'cash' | 'card';
+
+export type PaymentStatus = 'pending' | 'paid' | 'failed';
+
+export interface OrderContactInfo {
+  name: string;
+  phone: string;
+}
+
+export interface OrderDeliveryDetails {
+  address: string;
+  instructions?: string;
+}
+
+export interface OrderPaymentDetails {
+  method: PaymentMethod;
+  status?: PaymentStatus;
+}
+
 export interface User {
   id: string;
   username: string;
@@ -72,4 +91,22 @@ export interface Order {
   total: number;
   status: 'pending' | 'processing' | 'completed' | 'cancelled';
   createdAt: string;
+  contact: OrderContactInfo;
+  delivery: OrderDeliveryDetails;
+  payment: OrderPaymentDetails;
+}
+
+export interface CheckoutSnapshot {
+  items: CartItem[];
+  total: number;
+  createdAt: string;
+}
+
+export interface CreateOrderInput {
+  userId: string;
+  items: CartItem[];
+  total: number;
+  contact: OrderContactInfo;
+  delivery: OrderDeliveryDetails;
+  payment: OrderPaymentDetails;
 }


### PR DESCRIPTION
## Summary
- extend order types and store to track contact, delivery, and payment details
- add checkout store and page to capture fulfillment info before placing orders
- show delivery information in customer orders and admin dashboards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb1abe30608329a26d3af1f379e807