### PR TITLE
feat: add menu filters and item metadata

### DIFF
--- a/src/components/DrinkCard.tsx
+++ b/src/components/DrinkCard.tsx
@@ -1,9 +1,11 @@
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Drink } from '@/types';
 import { Button } from '@/components/ui/button';
 import { useCartStore } from '@/store/cartStore';
 import { toast } from 'sonner';
+import { Badge } from '@/components/ui/badge';
+import { getTagBadgeVariant, getTagLabel } from '@/lib/tag-utils';
 
 interface DrinkCardProps {
   drink: Drink;
@@ -12,6 +14,11 @@ interface DrinkCardProps {
 const DrinkCard = ({ drink }: DrinkCardProps) => {
   const [quantity, setQuantity] = useState(1);
   const { addDrinkToCart } = useCartStore();
+
+  const displayTags = useMemo(
+    () => Array.from(new Set(drink.tags ?? [])),
+    [drink]
+  );
 
   const handleAddToCart = () => {
     addDrinkToCart(drink.id, quantity);
@@ -28,6 +35,15 @@ const DrinkCard = ({ drink }: DrinkCardProps) => {
           className="w-full h-full object-cover"
         />
       </div>
+      {displayTags.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {displayTags.map(tag => (
+            <Badge key={tag} variant={getTagBadgeVariant(tag)}>
+              {getTagLabel(tag)}
+            </Badge>
+          ))}
+        </div>
+      )}
       <h3 className="text-lg font-semibold">{drink.name}</h3>
       <p className="text-gray-600 text-sm">{drink.description}</p>
       <p className="text-gray-500 text-sm mt-1">{drink.size}</p>

--- a/src/components/PizzaCard.tsx
+++ b/src/components/PizzaCard.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Pizza, Topping, PizzaSize } from '@/types';
 import { Button } from '@/components/ui/button';
 import {
@@ -21,6 +21,8 @@ import { Label } from '@/components/ui/label';
 import { toppings as allToppings } from '@/data/toppings';
 import { useCartStore } from '@/store/cartStore';
 import { toast } from 'sonner';
+import { Badge } from '@/components/ui/badge';
+import { getTagBadgeVariant, getTagLabel } from '@/lib/tag-utils';
 
 interface PizzaCardProps {
   pizza: Pizza;
@@ -34,9 +36,35 @@ const PizzaCard = ({ pizza }: PizzaCardProps) => {
   
   const { addPizzaToCart } = useCartStore();
   
-  const availableToppings = allToppings.filter(topping => 
+  const availableToppings = allToppings.filter(topping =>
     pizza.availableToppings.includes(topping.id) && topping.available
   );
+
+  const displayTags = useMemo(() => {
+    const tags = new Set<string>(pizza.tags ?? []);
+
+    if (pizza.isVegetarian) {
+      tags.add('vegetarian');
+    }
+
+    if (pizza.spiceLevel === 'medium' || pizza.spiceLevel === 'hot') {
+      tags.add('spicy');
+    }
+
+    return Array.from(tags);
+  }, [pizza]);
+
+  const formatBadgeLabel = (tag: string) => {
+    if (tag === 'spicy') {
+      if (pizza.spiceLevel === 'hot') {
+        return 'Extra Spicy';
+      }
+
+      return 'Spicy';
+    }
+
+    return getTagLabel(tag);
+  };
 
   const handleToppingToggle = (toppingId: string) => {
     setSelectedToppings(prev => 
@@ -82,6 +110,15 @@ const PizzaCard = ({ pizza }: PizzaCardProps) => {
           className="w-full h-full object-cover"
         />
       </div>
+      {displayTags.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {displayTags.map(tag => (
+            <Badge key={tag} variant={getTagBadgeVariant(tag)}>
+              {formatBadgeLabel(tag)}
+            </Badge>
+          ))}
+        </div>
+      )}
       <h3 className="text-lg font-semibold">{pizza.name}</h3>
       <p className="text-gray-600 text-sm mb-2 flex-1">{pizza.description}</p>
       <div className="flex justify-between items-center mt-auto pt-3">

--- a/src/data/drinks.ts
+++ b/src/data/drinks.ts
@@ -10,6 +10,7 @@ export const drinks: Drink[] = [
     price: 1.99,
     size: 'Small (12oz)',
     available: true,
+    tags: ['classic', 'vegan'],
   },
   {
     id: '2',
@@ -19,6 +20,7 @@ export const drinks: Drink[] = [
     price: 2.49,
     size: 'Medium (20oz)',
     available: true,
+    tags: ['classic', 'vegan'],
   },
   {
     id: '3',
@@ -28,6 +30,7 @@ export const drinks: Drink[] = [
     price: 2.99,
     size: 'Large (32oz)',
     available: true,
+    tags: ['classic', 'vegan'],
   },
   {
     id: '4',
@@ -37,6 +40,7 @@ export const drinks: Drink[] = [
     price: 1.99,
     size: 'Small (12oz)',
     available: true,
+    tags: ['classic', 'vegan', 'caffeine-free'],
   },
   {
     id: '5',
@@ -46,6 +50,7 @@ export const drinks: Drink[] = [
     price: 2.49,
     size: 'Medium (20oz)',
     available: true,
+    tags: ['classic', 'vegan', 'caffeine-free'],
   },
   {
     id: '6',
@@ -55,6 +60,7 @@ export const drinks: Drink[] = [
     price: 2.99,
     size: 'Large (32oz)',
     available: true,
+    tags: ['classic', 'vegan', 'caffeine-free'],
   },
   {
     id: '7',
@@ -64,6 +70,7 @@ export const drinks: Drink[] = [
     price: 1.49,
     size: 'Bottled (16.9oz)',
     available: true,
+    tags: ['vegan', 'caffeine-free', 'sugar-free'],
   },
   {
     id: '8',
@@ -73,5 +80,6 @@ export const drinks: Drink[] = [
     price: 2.99,
     size: 'Regular (16oz)',
     available: true,
+    tags: ['vegetarian', 'vegan'],
   }
 ];

--- a/src/data/pizzas.ts
+++ b/src/data/pizzas.ts
@@ -12,7 +12,10 @@ export const pizzas: Pizza[] = [
       medium: 10.99,
       large: 12.99,
     },
-    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8']
+    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8'],
+    isVegetarian: true,
+    spiceLevel: 'mild',
+    tags: ['vegetarian', 'classic'],
   },
   {
     id: '2',
@@ -24,7 +27,10 @@ export const pizzas: Pizza[] = [
       medium: 11.99,
       large: 13.99,
     },
-    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8']
+    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8'],
+    isVegetarian: false,
+    spiceLevel: 'mild',
+    tags: ['classic'],
   },
   {
     id: '3',
@@ -36,7 +42,10 @@ export const pizzas: Pizza[] = [
       medium: 11.99,
       large: 13.99,
     },
-    availableToppings: ['1', '2', '3', '5', '7', '8']
+    availableToppings: ['1', '2', '3', '5', '7', '8'],
+    isVegetarian: true,
+    spiceLevel: 'mild',
+    tags: ['vegetarian', 'garden-fresh'],
   },
   {
     id: '4',
@@ -48,7 +57,10 @@ export const pizzas: Pizza[] = [
       medium: 12.99,
       large: 14.99,
     },
-    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8']
+    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8'],
+    isVegetarian: false,
+    spiceLevel: 'mild',
+    tags: ['sweet-savory'],
   },
   {
     id: '5',
@@ -60,7 +72,10 @@ export const pizzas: Pizza[] = [
       medium: 13.99,
       large: 15.99,
     },
-    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8']
+    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8'],
+    isVegetarian: false,
+    spiceLevel: 'medium',
+    tags: ['spicy', 'loaded'],
   },
   {
     id: '6',
@@ -72,6 +87,9 @@ export const pizzas: Pizza[] = [
       medium: 13.99,
       large: 15.99,
     },
-    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8']
+    availableToppings: ['1', '2', '3', '4', '5', '6', '7', '8'],
+    isVegetarian: false,
+    spiceLevel: 'medium',
+    tags: ['spicy', 'bbq'],
   }
 ];

--- a/src/lib/tag-utils.ts
+++ b/src/lib/tag-utils.ts
@@ -1,0 +1,38 @@
+import type { DietaryTag } from '@/types';
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+const TAG_LABEL_OVERRIDES: Record<string, string> = {
+  vegetarian: 'Vegetarian',
+  vegan: 'Vegan',
+  spicy: 'Spicy',
+  bbq: 'BBQ',
+  'garden-fresh': 'Garden Fresh',
+  'sweet-savory': 'Sweet & Savory',
+  loaded: 'Loaded',
+  classic: 'Classic',
+  'caffeine-free': 'Caffeine Free',
+  'sugar-free': 'Sugar Free',
+  'gluten-free': 'Gluten-Free',
+};
+
+const startCase = (value: string) =>
+  value
+    .split(/[-_]/)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+export const getTagLabel = (tag: DietaryTag | string) =>
+  TAG_LABEL_OVERRIDES[tag] ?? startCase(tag);
+
+export const getTagBadgeVariant = (tag: DietaryTag | string): BadgeVariant => {
+  if (tag === 'spicy') {
+    return 'destructive';
+  }
+
+  if (tag === 'vegetarian' || tag === 'vegan') {
+    return 'secondary';
+  }
+
+  return 'outline';
+};

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -1,18 +1,191 @@
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import PizzaCard from '@/components/PizzaCard';
 import DrinkCard from '@/components/DrinkCard';
 import { pizzas } from '@/data/pizzas';
 import { drinks } from '@/data/drinks';
+import { Input } from '@/components/ui/input';
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { getTagLabel } from '@/lib/tag-utils';
 
 const Menu = () => {
   const [activeTab, setActiveTab] = useState('pizzas');
+  const priceStats = useMemo(() => {
+    const pizzaBasePrices = pizzas.map(pizza => Math.min(...Object.values(pizza.price)));
+    const drinkPrices = drinks.map(drink => drink.price);
+    const combined = [...pizzaBasePrices, ...drinkPrices].filter(price => typeof price === 'number');
+
+    if (combined.length === 0) {
+      return { floor: 0, ceiling: 0 };
+    }
+
+    const floor = Math.floor(Math.min(...combined));
+    const ceiling = Math.ceil(Math.max(...combined));
+
+    return { floor, ceiling: ceiling || floor };
+  }, []);
+
+  const [searchTerm, setSearchTerm] = useState('');
+  const [maxPrice, setMaxPrice] = useState(priceStats.ceiling);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  const availableTags = useMemo(() => {
+    const tags = new Set<string>();
+
+    pizzas.forEach(pizza => {
+      pizza.tags?.forEach(tag => tags.add(tag));
+
+      if (pizza.isVegetarian) {
+        tags.add('vegetarian');
+      }
+
+      if (pizza.spiceLevel === 'medium' || pizza.spiceLevel === 'hot') {
+        tags.add('spicy');
+      }
+    });
+
+    drinks.forEach(drink => {
+      drink.tags?.forEach(tag => tags.add(tag));
+    });
+
+    return Array.from(tags).sort((a, b) => getTagLabel(a).localeCompare(getTagLabel(b)));
+  }, []);
+
+  const filteredPizzas = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+
+    return pizzas.filter(pizza => {
+      const lowestPrice = Math.min(...Object.values(pizza.price));
+
+      if (lowestPrice > maxPrice) {
+        return false;
+      }
+
+      if (
+        normalized &&
+        ![pizza.name, pizza.description].some(field => field.toLowerCase().includes(normalized))
+      ) {
+        return false;
+      }
+
+      if (selectedTags.length === 0) {
+        return true;
+      }
+
+      return selectedTags.every(tag => {
+        if (tag === 'vegetarian') {
+          return Boolean(pizza.isVegetarian);
+        }
+
+        if (tag === 'spicy') {
+          return pizza.spiceLevel === 'medium' || pizza.spiceLevel === 'hot';
+        }
+
+        return pizza.tags?.includes(tag);
+      });
+    });
+  }, [maxPrice, searchTerm, selectedTags]);
+
+  const filteredDrinks = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+
+    return drinks.filter(drink => {
+      if (drink.price > maxPrice) {
+        return false;
+      }
+
+      if (
+        normalized &&
+        ![drink.name, drink.description].some(field => field.toLowerCase().includes(normalized))
+      ) {
+        return false;
+      }
+
+      if (selectedTags.length === 0) {
+        return true;
+      }
+
+      return selectedTags.every(tag => drink.tags?.includes(tag));
+    });
+  }, [maxPrice, searchTerm, selectedTags]);
+
+  const handleMaxPriceChange = (value: number[]) => {
+    const nextPrice = value[0];
+    setMaxPrice(nextPrice !== undefined ? nextPrice : priceStats.ceiling);
+  };
+
+  const handleTagSelection = (value: string[]) => {
+    setSelectedTags(value);
+  };
 
   return (
     <div className="container mx-auto px-4 py-12">
       <h1 className="text-3xl md:text-4xl font-bold text-center mb-8 font-display">Our Menu</h1>
-      
+
+      <div className="mb-8 space-y-6">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="menu-search">Search menu</Label>
+            <Input
+              id="menu-search"
+              type="search"
+              placeholder="Search for pizzas or drinks..."
+              value={searchTerm}
+              onChange={event => setSearchTerm(event.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="price-filter">Maximum price</Label>
+            <div className="px-1">
+              <Slider
+                id="price-filter"
+                min={Math.max(0, priceStats.floor)}
+                max={priceStats.ceiling}
+                step={0.5}
+                value={[maxPrice]}
+                onValueChange={handleMaxPriceChange}
+              />
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>${Math.max(0, priceStats.floor).toFixed(2)}</span>
+              <span>Up to ${maxPrice.toFixed(2)}</span>
+              <span>${priceStats.ceiling.toFixed(2)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label>Dietary tags</Label>
+          {availableTags.length ? (
+            <ToggleGroup
+              type="multiple"
+              value={selectedTags}
+              onValueChange={handleTagSelection}
+              className="flex flex-wrap justify-start gap-2"
+            >
+              {availableTags.map(tag => (
+                <ToggleGroupItem
+                  key={tag}
+                  value={tag}
+                  aria-label={getTagLabel(tag)}
+                  variant="outline"
+                  size="sm"
+                  className="capitalize data-[state=on]:bg-pizza-600 data-[state=on]:text-white"
+                >
+                  {getTagLabel(tag)}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          ) : (
+            <p className="text-sm text-muted-foreground">No tags available yet.</p>
+          )}
+        </div>
+      </div>
+
       <Tabs defaultValue="pizzas" value={activeTab} onValueChange={setActiveTab} className="w-full">
         <div className="flex justify-center mb-6">
           <TabsList>
@@ -20,21 +193,33 @@ const Menu = () => {
             <TabsTrigger value="drinks" className="px-8">Drinks</TabsTrigger>
           </TabsList>
         </div>
-        
+
         <TabsContent value="pizzas">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {pizzas.map(pizza => (
-              <PizzaCard key={pizza.id} pizza={pizza} />
-            ))}
-          </div>
+          {filteredPizzas.length ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filteredPizzas.map(pizza => (
+                <PizzaCard key={pizza.id} pizza={pizza} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+              No pizzas match your filters. Try adjusting your search or filters.
+            </div>
+          )}
         </TabsContent>
-        
+
         <TabsContent value="drinks">
-          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {drinks.map(drink => (
-              <DrinkCard key={drink.id} drink={drink} />
-            ))}
-          </div>
+          {filteredDrinks.length ? (
+            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+              {filteredDrinks.map(drink => (
+                <DrinkCard key={drink.id} drink={drink} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+              No drinks match your filters. Try adjusting your search or filters.
+            </div>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,21 @@ export interface Topping {
   available: boolean;
 }
 
+export type SpiceLevel = 'none' | 'mild' | 'medium' | 'hot';
+
+export type DietaryTag =
+  | 'vegetarian'
+  | 'vegan'
+  | 'gluten-free'
+  | 'spicy'
+  | 'classic'
+  | 'garden-fresh'
+  | 'sweet-savory'
+  | 'loaded'
+  | 'bbq'
+  | 'caffeine-free'
+  | 'sugar-free';
+
 export interface Pizza {
   id: string;
   name: string;
@@ -23,6 +38,9 @@ export interface Pizza {
     large: number;
   };
   availableToppings: string[]; // IDs of available toppings
+  tags?: DietaryTag[];
+  spiceLevel?: SpiceLevel;
+  isVegetarian?: boolean;
 }
 
 export interface Drink {
@@ -33,6 +51,7 @@ export interface Drink {
   price: number;
   size: string;
   available: boolean;
+  tags?: DietaryTag[];
 }
 
 export interface CartPizzaItem {


### PR DESCRIPTION
## Summary
- enrich pizza and drink data with dietary metadata and extend the shared types
- add search, price, and tag filters to the menu view with empty states when nothing matches
- surface tag badges on menu cards using a shared tag utility for consistent labelling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb1e929b6483298c5afb8be70b4f78