### PR TITLE
Add analytics widgets to admin dashboard

### DIFF
--- a/src/components/OrderAnalytics.tsx
+++ b/src/components/OrderAnalytics.tsx
@@ -1,0 +1,129 @@
+import { useMemo } from 'react';
+import { CartesianGrid, Cell, Line, LineChart, Pie, PieChart, XAxis, YAxis } from 'recharts';
+
+import type { OrderAnalyticsMetrics } from '@/hooks/use-order-analytics';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@/components/ui/chart';
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: '#f59e0b',
+  processing: '#3b82f6',
+  completed: '#22c55e',
+  cancelled: '#ef4444',
+};
+
+type OrderAnalyticsProps = {
+  metrics: OrderAnalyticsMetrics;
+};
+
+const OrderAnalytics = ({ metrics }: OrderAnalyticsProps) => {
+  const revenueConfig = useMemo<ChartConfig>(
+    () => ({
+      revenue: {
+        label: 'Revenue',
+        color: 'hsl(var(--primary))',
+      },
+    }),
+    [],
+  );
+
+  const statusConfig = useMemo<ChartConfig>(() => {
+    const entries = metrics.statusSummaries.map((summary) => [
+      summary.status,
+      {
+        label: summary.label,
+        color: STATUS_COLORS[summary.status] ?? 'hsl(var(--muted-foreground))',
+      },
+    ] as const);
+    return Object.fromEntries(entries);
+  }, [metrics.statusSummaries]);
+
+  const hasRevenueData = metrics.dailyRevenue.length > 0;
+  const hasStatusData = metrics.statusSummaries.some((summary) => summary.count > 0);
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold">Revenue Over Time</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {hasRevenueData ? (
+            <ChartContainer config={revenueConfig} className="h-[260px]">
+              <LineChart data={metrics.dailyRevenue} margin={{ left: 12, right: 12, top: 8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="label" tickLine={false} axisLine={false} interval="preserveStartEnd" />
+                <YAxis tickLine={false} axisLine={false} width={80} />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value) => `Revenue: $${Number(value).toFixed(2)}`}
+                      labelFormatter={(label) => `Date: ${label}`}
+                    />
+                  }
+                />
+                <Line
+                  type="monotone"
+                  dataKey="revenue"
+                  stroke="var(--color-revenue)"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                />
+              </LineChart>
+            </ChartContainer>
+          ) : (
+            <div className="flex h-[260px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
+              <p>No revenue data for the selected range.</p>
+              <p className="mt-1">Orders will appear here once they start coming in.</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold">Order Status Mix</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {hasStatusData ? (
+            <ChartContainer config={statusConfig} className="h-[260px]">
+              <PieChart>
+                <Pie data={metrics.statusSummaries} dataKey="count" nameKey="label" innerRadius={60} outerRadius={90}>
+                  {metrics.statusSummaries.map((summary) => (
+                    <Cell key={summary.status} fill={STATUS_COLORS[summary.status] ?? '#a1a1aa'} />
+                  ))}
+                </Pie>
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value, name) => `${name}: ${value}`}
+                      labelFormatter={() => 'Order Status'}
+                    />
+                  }
+                />
+                <ChartLegend
+                  content={<ChartLegendContent className="flex flex-wrap justify-center gap-4 text-xs" />}
+                />
+              </PieChart>
+            </ChartContainer>
+          ) : (
+            <div className="flex h-[260px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
+              <p>No orders to visualize yet.</p>
+              <p className="mt-1">Place or import orders to see the status distribution.</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default OrderAnalytics;

--- a/src/hooks/use-order-analytics.ts
+++ b/src/hooks/use-order-analytics.ts
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import { format, parseISO, startOfDay, subDays } from 'date-fns';
+
+import type { Order } from '@/types';
+
+type OrderStatus = Order['status'];
+
+type DailyRevenuePoint = {
+  date: string;
+  label: string;
+  revenue: number;
+  orderCount: number;
+};
+
+type StatusSummary = {
+  status: OrderStatus;
+  label: string;
+  count: number;
+};
+
+export type OrderAnalyticsMetrics = {
+  totalOrders: number;
+  totalRevenue: number;
+  averageOrderValue: number;
+  revenueThisWeek: number;
+  statusSummaries: StatusSummary[];
+  dailyRevenue: DailyRevenuePoint[];
+  hasOrders: boolean;
+};
+
+const STATUS_LABELS: Record<OrderStatus, string> = {
+  pending: 'Pending',
+  processing: 'Processing',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+};
+
+export const useOrderAnalytics = (orders: Order[]): OrderAnalyticsMetrics => {
+  return useMemo(() => {
+    if (orders.length === 0) {
+      return {
+        totalOrders: 0,
+        totalRevenue: 0,
+        averageOrderValue: 0,
+        revenueThisWeek: 0,
+        statusSummaries: (Object.keys(STATUS_LABELS) as OrderStatus[]).map((status) => ({
+          status,
+          label: STATUS_LABELS[status],
+          count: 0,
+        })),
+        dailyRevenue: [],
+        hasOrders: false,
+      };
+    }
+
+    const now = new Date();
+    const weekStart = startOfDay(subDays(now, 6));
+
+    let totalRevenue = 0;
+    const statusCounts: Record<OrderStatus, number> = {
+      pending: 0,
+      processing: 0,
+      completed: 0,
+      cancelled: 0,
+    };
+
+    const revenueByDay = new Map<string, { revenue: number; orderCount: number; date: Date }>();
+    let revenueThisWeek = 0;
+
+    orders.forEach((order) => {
+      const orderDate = parseISO(order.createdAt);
+      if (Number.isNaN(orderDate.getTime())) {
+        return;
+      }
+
+      totalRevenue += order.total;
+      statusCounts[order.status] += 1;
+
+      const dayKey = format(orderDate, 'yyyy-MM-dd');
+      const existing = revenueByDay.get(dayKey);
+      if (existing) {
+        existing.revenue += order.total;
+        existing.orderCount += 1;
+      } else {
+        revenueByDay.set(dayKey, {
+          revenue: order.total,
+          orderCount: 1,
+          date: orderDate,
+        });
+      }
+
+      if (orderDate >= weekStart) {
+        revenueThisWeek += order.total;
+      }
+    });
+
+    const totalOrders = orders.length;
+    const averageOrderValue = totalOrders ? totalRevenue / totalOrders : 0;
+
+    const dailyRevenue: DailyRevenuePoint[] = Array.from(revenueByDay.values())
+      .sort((a, b) => a.date.getTime() - b.date.getTime())
+      .map(({ date, revenue, orderCount }) => ({
+        date: format(date, 'yyyy-MM-dd'),
+        label: format(date, 'MMM d'),
+        revenue,
+        orderCount,
+      }));
+
+    const statusSummaries: StatusSummary[] = (Object.keys(STATUS_LABELS) as OrderStatus[]).map((status) => ({
+      status,
+      label: STATUS_LABELS[status],
+      count: statusCounts[status],
+    }));
+
+    return {
+      totalOrders,
+      totalRevenue,
+      averageOrderValue,
+      revenueThisWeek,
+      statusSummaries,
+      dailyRevenue,
+      hasOrders: totalOrders > 0,
+    };
+  }, [orders]);
+};
+
+export default useOrderAnalytics;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,126 +1,380 @@
+import { useMemo, useState } from 'react';
+import { format, parseISO, startOfDay, subDays } from 'date-fns';
+import { Info } from 'lucide-react';
+import { toast } from 'sonner';
 
+import OrderAnalytics from '@/components/OrderAnalytics';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { useOrderStore } from '@/store/orderStore';
+import useOrderAnalytics from '@/hooks/use-order-analytics';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { format } from 'date-fns';
-import { toast } from 'sonner';
+} from '@/components/ui/select';
+
+import type { Order } from '@/types';
+
+type OrderStatusFilter = 'all' | Order['status'];
+type DateRangeFilter = 'all' | '7d' | '30d' | '90d';
+
+const DATE_RANGE_DAYS: Record<Exclude<DateRangeFilter, 'all'>, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
 
 const Admin = () => {
   const { getAllOrders, updateOrderStatus } = useOrderStore();
 
+  const [statusFilter, setStatusFilter] = useState<OrderStatusFilter>('all');
+  const [dateFilter, setDateFilter] = useState<DateRangeFilter>('all');
+
   const orders = getAllOrders();
 
-  const handleStatusChange = (orderId: string, status: 'pending' | 'processing' | 'completed' | 'cancelled') => {
+  const filteredOrders = useMemo(() => {
+    if (orders.length === 0) {
+      return [] as Order[];
+    }
+
+    const now = new Date();
+    const rangeStart =
+      dateFilter === 'all'
+        ? null
+        : startOfDay(subDays(now, DATE_RANGE_DAYS[dateFilter] - 1));
+
+    return orders.filter((order) => {
+      const matchesStatus = statusFilter === 'all' || order.status === statusFilter;
+      if (!matchesStatus) {
+        return false;
+      }
+
+      if (!rangeStart) {
+        return true;
+      }
+
+      const orderDate = parseISO(order.createdAt);
+      if (Number.isNaN(orderDate.getTime())) {
+        return false;
+      }
+
+      return orderDate >= rangeStart;
+    });
+  }, [orders, statusFilter, dateFilter]);
+
+  const analytics = useOrderAnalytics(filteredOrders);
+
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }),
+    [],
+  );
+
+  const kpiCards = useMemo(() => {
+    const statusCount = (status: Exclude<OrderStatusFilter, 'all'>) =>
+      analytics.statusSummaries.find((summary) => summary.status === status)?.count ?? 0;
+
+    const hasOrders = analytics.hasOrders;
+
+    return [
+      {
+        key: 'total-orders',
+        title: 'Total Orders',
+        value: analytics.totalOrders.toLocaleString(),
+        tooltip: 'Total number of orders returned by the current filters.',
+        helper: hasOrders ? 'Includes every order across statuses.' : 'Waiting for your first order.',
+      },
+      {
+        key: 'total-revenue',
+        title: 'Total Revenue',
+        value: currencyFormatter.format(analytics.totalRevenue),
+        tooltip: 'Sum of order totals for the filtered selection.',
+        helper: hasOrders
+          ? 'Gross revenue before refunds or adjustments.'
+          : 'Revenue appears after the first order.',
+      },
+      {
+        key: 'revenue-week',
+        title: 'Revenue (Last 7 Days)',
+        value: currencyFormatter.format(analytics.revenueThisWeek),
+        tooltip: 'Revenue generated during the past seven days within the filtered data.',
+        helper: hasOrders
+          ? 'Useful for spotting short-term momentum.'
+          : 'No revenue recorded in the last week yet.',
+      },
+      {
+        key: 'average-order-value',
+        title: 'Average Order Value',
+        value: hasOrders ? currencyFormatter.format(analytics.averageOrderValue) : '--',
+        tooltip: 'Average amount spent per order in the current selection.',
+        helper: hasOrders
+          ? 'A higher value indicates larger baskets.'
+          : 'Average order value will populate after orders arrive.',
+      },
+      {
+        key: 'pending-orders',
+        title: 'Pending Orders',
+        value: statusCount('pending').toLocaleString(),
+        tooltip: 'Orders awaiting confirmation or processing.',
+        helper: hasOrders
+          ? 'Follow up to keep customers informed.'
+          : 'No pending orders at the moment.',
+      },
+      {
+        key: 'completed-orders',
+        title: 'Completed Orders',
+        value: statusCount('completed').toLocaleString(),
+        tooltip: 'Orders fulfilled and marked as completed.',
+        helper: hasOrders
+          ? 'Represents successful deliveries or pickups.'
+          : 'Completed orders will appear once fulfilled.',
+      },
+    ];
+  }, [analytics, currencyFormatter]);
+
+  const handleStatusChange = (
+    orderId: string,
+    status: 'pending' | 'processing' | 'completed' | 'cancelled',
+  ) => {
     updateOrderStatus(orderId, status);
     toast.success(`Order status updated to ${status}`);
   };
+
+  const hasOrders = filteredOrders.length > 0;
 
   return (
     <div className="container mx-auto px-4 py-12">
       <h1 className="text-3xl font-bold mb-8">Admin Dashboard</h1>
 
-      <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-xl font-semibold mb-4">Order Management</h2>
-
-        {orders.length === 0 ? (
-          <p className="text-gray-500">No orders to display</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Order ID
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Customer
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Date
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Total
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Delivery
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Payment
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Items
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {orders.map((order) => (
-                  <tr key={order.id}>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                      {order.id.slice(0, 8)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {order.userId}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {format(new Date(order.createdAt), 'MMM d, yyyy h:mm a')}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      ${order.total.toFixed(2)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <Select
-                        value={order.status}
-                        onValueChange={(value) => handleStatusChange(
-                          order.id,
-                          value as 'pending' | 'processing' | 'completed' | 'cancelled'
-                        )}
-                      >
-                        <SelectTrigger className="w-[140px]">
-                          <SelectValue placeholder="Status" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="pending">Pending</SelectItem>
-                          <SelectItem value="processing">Processing</SelectItem>
-                          <SelectItem value="completed">Completed</SelectItem>
-                          <SelectItem value="cancelled">Cancelled</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      <div>
-                        <p className="font-medium text-gray-900">{order.contact.name || 'N/A'}</p>
-                        <p>{order.contact.phone || 'N/A'}</p>
-                        <p className="truncate max-w-[200px]" title={order.delivery.address}>
-                          {order.delivery.address || 'N/A'}
-                        </p>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      <p className="capitalize">{order.payment.method.replace('-', ' ')}</p>
-                      <p className="capitalize text-gray-400">{(order.payment.status ?? 'pending').replace('-', ' ')}</p>
-                      {order.delivery.instructions && (
-                        <p className="text-gray-400 text-xs truncate max-w-[200px]" title={order.delivery.instructions}>
-                          Notes: {order.delivery.instructions}
-                        </p>
-                      )}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {order.items.length} items
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      <div className="space-y-8">
+        <div className="rounded-lg bg-white shadow-sm p-6 space-y-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Sales Overview</h2>
+              <p className="text-sm text-muted-foreground">
+                Track performance and monitor order trends in real time.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-4">
+              <div className="space-y-1">
+                <p className="text-xs font-medium uppercase text-muted-foreground">Status</p>
+                <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as OrderStatusFilter)}>
+                  <SelectTrigger className="w-[180px]">
+                    <SelectValue placeholder="Status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All statuses</SelectItem>
+                    <SelectItem value="pending">Pending</SelectItem>
+                    <SelectItem value="processing">Processing</SelectItem>
+                    <SelectItem value="completed">Completed</SelectItem>
+                    <SelectItem value="cancelled">Cancelled</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs font-medium uppercase text-muted-foreground">Date Range</p>
+                <Select value={dateFilter} onValueChange={(value) => setDateFilter(value as DateRangeFilter)}>
+                  <SelectTrigger className="w-[180px]">
+                    <SelectValue placeholder="Date range" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All time</SelectItem>
+                    <SelectItem value="7d">Last 7 days</SelectItem>
+                    <SelectItem value="30d">Last 30 days</SelectItem>
+                    <SelectItem value="90d">Last 90 days</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
           </div>
-        )}
+
+          <TooltipProvider>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {kpiCards.map((card) => (
+                <Card key={card.key}>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="rounded-full p-1 text-muted-foreground transition hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                          aria-label={`More info about ${card.title}`}
+                        >
+                          <Info className="h-4 w-4" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>{card.tooltip}</TooltipContent>
+                    </Tooltip>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="text-2xl font-semibold tracking-tight">{card.value}</div>
+                    <CardDescription className="mt-2">{card.helper}</CardDescription>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </TooltipProvider>
+        </div>
+
+        <OrderAnalytics metrics={analytics} />
+
+        <div className="bg-white rounded-lg shadow-sm p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Order Management</h2>
+            <p className="text-sm text-muted-foreground">
+              Update statuses and review order details.
+            </p>
+          </div>
+
+          {!hasOrders ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-sm text-muted-foreground">
+              <p>
+                {orders.length === 0
+                  ? 'No orders to display yet.'
+                  : 'No orders match the selected filters.'}
+              </p>
+              <p className="text-xs">
+                {orders.length === 0
+                  ? 'Orders will appear here once customers complete checkout.'
+                  : 'Adjust the filters above to broaden your results.'}
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Order ID
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Customer
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Date
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Total
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Status
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Delivery
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Payment
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Items
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {filteredOrders.map((order) => (
+                    <tr key={order.id}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        {order.id.slice(0, 8)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{order.userId}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {format(new Date(order.createdAt), 'MMM d, yyyy h:mm a')}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        ${order.total.toFixed(2)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <Select
+                          value={order.status}
+                          onValueChange={(value) =>
+                            handleStatusChange(
+                              order.id,
+                              value as 'pending' | 'processing' | 'completed' | 'cancelled',
+                            )
+                          }
+                        >
+                          <SelectTrigger className="w-[140px]">
+                            <SelectValue placeholder="Status" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="pending">Pending</SelectItem>
+                            <SelectItem value="processing">Processing</SelectItem>
+                            <SelectItem value="completed">Completed</SelectItem>
+                            <SelectItem value="cancelled">Cancelled</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <div>
+                          <p className="font-medium text-gray-900">{order.contact.name || 'N/A'}</p>
+                          <p>{order.contact.phone || 'N/A'}</p>
+                          <p className="truncate max-w-[200px]" title={order.delivery.address}>
+                            {order.delivery.address || 'N/A'}
+                          </p>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <p className="capitalize">{order.payment.method.replace('-', ' ')}</p>
+                        <p className="capitalize text-gray-400">
+                          {(order.payment.status ?? 'pending').replace('-', ' ')}
+                        </p>
+                        {order.delivery.instructions && (
+                          <p
+                            className="text-gray-400 text-xs truncate max-w-[200px]"
+                            title={order.delivery.instructions}
+                          >
+                            Notes: {order.delivery.instructions}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {order.items.length} items
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a reusable order analytics hook for memoized KPI calculations and chart data
- create an OrderAnalytics component with revenue and status charts plus empty states
- enhance the admin dashboard with filters, KPI cards, analytics, and resilient table messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb238268008329b09c6e1d2645ca63