### PR TITLE
Update admin tooling capability description

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ To connect a domain, navigate to Project > Settings > Domains and click Connect 
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 
+## Current Capabilities
+
+- Customer ordering experience that lets guests browse pizzas and drinks, filter by preferences, and build customized carts ready for checkout.
+- Checkout flow that captures delivery details, contact information, and payment preferences before routing customers to their order history.
+- Admin tooling with dashboards that surface sales analytics and streamline day-to-day order management for the team.
+
 ## Upcoming Improvements
 
 The following initiatives are on the roadmap and have not shipped yet:


### PR DESCRIPTION
## Summary
- add a Current Capabilities section to the README
- highlight the admin tooling focus on analytics and order management without mentioning inventory controls

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68cb3c7946a88329bb0bbfa480b8ed61