### PR TITLE
Replace social preview imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
     <meta property="og:title" content="PizzaDelight - Fresh & Delicious Pizza" />
     <meta property="og:description" content="Order delicious pizzas with customizable toppings and drinks for delivery or pickup" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:image" content="/og-image.svg" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@pizzadelight" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:image" content="/og-image.svg" />
   </head>
 
   <body>

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffb347" />
+      <stop offset="100%" stop-color="#ffcc33" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <g transform="translate(600 315)" text-anchor="middle" font-family="'Baloo 2', 'Segoe UI', sans-serif">
+    <text y="-40" font-size="120" fill="#3b2102" font-weight="700">Cheesy Cart</text>
+    <text y="80" font-size="64" fill="#5c3504">Fresh Pizza, Fast Delivery</text>
+  </g>
+  <g transform="translate(960 150)">
+    <circle cx="0" cy="0" r="90" fill="#fff2cc" stroke="#3b2102" stroke-width="12" />
+    <circle cx="0" cy="0" r="45" fill="#ff944d" stroke="#3b2102" stroke-width="8" />
+    <path d="M-35 -10 Q0 -45 35 -10" fill="none" stroke="#3b2102" stroke-width="12" stroke-linecap="round" />
+    <path d="M-30 20 Q0 55 30 20" fill="none" stroke="#3b2102" stroke-width="12" stroke-linecap="round" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a locally owned open graph illustration for social sharing
- point og:image and twitter:image meta tags at the new asset

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68cb40ccd2c0832990f0bc5fbe9a203d